### PR TITLE
fix: update health check URL to use the correct website address

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Website Health Check
         run: |
           echo "Checking website health..."
-          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "${{ env.WEBSITE_URL }}" || echo "000")
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "${{ 'https://launchtech.co.in' }}" || echo "000")
           echo "HTTP Response Code: $RESPONSE"
           if [ "$RESPONSE" -eq 200 ]; then
             echo "✓ Website is accessible and responding correctly"


### PR DESCRIPTION
This pull request updates the website health check step in the deployment workflow to use a hardcoded URL instead of the previous environment variable. This ensures the health check always targets `https://launchtech.co.in`.

Deployment workflow update:

* Changed the `Website Health Check` step in `.github/workflows/deploy.yml` to use the hardcoded URL `https://launchtech.co.in` instead of `${{ env.WEBSITE_URL }}` for the HTTP response check.